### PR TITLE
Ensures git config works inside runtime

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -54,6 +54,10 @@ jobs:
               git config --global user.name 'openhands-bot'
               git config --global user.email 'openhands-bot@users.noreply.github.com'
               export TERM=xterm
+              # Ensure git config works inside runtime
+              unset GIT_CONFIG GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM GIT_CONFIG_NOSYSTEM || true
+              git config --global core.pager "" || true
+              git config --global --add safe.directory /workspace || true
               /app/.venv/bin/playwright install chromium || true
               /app/.venv/bin/playwright install-deps chromium || true
               /app/.venv/bin/python -m openhands.resolver.resolve_issue \


### PR DESCRIPTION
The GitHub Actions environment might not have a fully configured git environment. This change explicitly configures git to ensure it functions correctly within the runtime environment, which is required by the openhands resolver script.

- Unsets environment variables that might interfere with git configuration
- Disables git pager
- Adds /workspace to the safe directory for git