### PR TITLE
Ensures git wrapper script is POSIX compliant

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -65,9 +65,9 @@ jobs:
               # Replace system git with a wrapper to sanitize env for ALL git calls
               if [ -x /usr/bin/git ] && [ ! -x /usr/bin/git.real ]; then mv /usr/bin/git /usr/bin/git.real; fi
               echo "[resolver] installing git wrapper..."
-              echo '#!/bin/sh' > /usr/bin/git
-              echo 'unset GIT_CONFIG GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM GIT_CONFIG_NOSYSTEM GIT_CONFIG_COUNT' >> /usr/bin/git
-              echo 'exec /usr/bin/git.real "$@"' >> /usr/bin/git
+              echo "#!/bin/sh" > /usr/bin/git
+              echo "unset GIT_CONFIG GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM GIT_CONFIG_NOSYSTEM GIT_CONFIG_COUNT" >> /usr/bin/git
+              echo "exec /usr/bin/git.real \"\$@\"" >> /usr/bin/git
               chmod +x /usr/bin/git
               echo "[resolver] git wrapper installed."
               unset GIT_CONFIG GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM GIT_CONFIG_NOSYSTEM || true


### PR DESCRIPTION
Updates the git wrapper script to be POSIX compliant by using double quotes for variable expansion.

This change ensures that the wrapper script functions correctly in environments with strict POSIX shell implementations.