### PR TITLE
Renames instruction file argument for clarity

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -112,7 +112,7 @@ jobs:
               # Build optional instructions flag if repository provides one at root
               INSTRUCTIONS_ARGS=""
               if [ -f /workspace/.openhands_instructions ]; then
-                INSTRUCTIONS_ARGS="--instructions-file /workspace/.openhands_instructions"
+                INSTRUCTIONS_ARGS="--repo-instruction-file /workspace/.openhands_instructions"
                 echo "[resolver] using custom instructions file at /workspace/.openhands_instructions"
               fi
               env -i \

--- a/.openhands_instructions
+++ b/.openhands_instructions
@@ -1,6 +1,7 @@
-You are fixing issues in a monorepo with Angular frontend and .NET backend following Onion Architecture.
+# You are fixing issues in a monorepo with Angular frontend and .NET backend following Onion Architecture.
 
 Key rules:
+
 - Do not modify unrelated files. Keep edits minimal and high quality.
 - Prefer focused PRs with clear descriptions and tests.
 - Backend (.NET): EF Core + MediatR + repositories + unit of work; write unit + integration tests.
@@ -10,10 +11,12 @@ Key rules:
 - Docker: multi-stage builds, health checks.
 
 When adding API endpoints:
+
 - Start with Domain/Application (DTOs, handlers), then Infrastructure (repos/EF queries), then API controllers.
 - Add tests under `src/GarageInventory.Tests`.
 - Return consistent error responses.
 
 When done:
+
 - Run unit/integration tests and ensure build succeeds.
 - Provide a concise PR description summarizing changes and tests.


### PR DESCRIPTION
Updates the command-line argument name for specifying a repository-specific instruction file to improve clarity and consistency.

The change from `--instructions-file` to
`--repo-instruction-file` better reflects the purpose of the file.