### PR TITLE
fix: syntax error in bash script

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -242,7 +242,7 @@ jobs:
                 fi
                 
                 # Check for any commits that haven't been pushed
-                CURRENT_BRANCH=$(git branch --show-current)
+                CURRENT_BRANCH=`git branch --show-current`
                 echo "[resolver] Current branch: ${CURRENT_BRANCH}"
                 
                 # Check if there are commits not on origin/main


### PR DESCRIPTION
Changed  to backticks for command substitution inside single-quoted script This fixes 'syntax error near unexpected token' error