### PR TITLE
fix: remove apostrophe from comment inside single-quoted bash script

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -241,7 +241,7 @@ jobs:
                   cd /workspace
                 fi
                 
-                # Check for any commits that haven't been pushed
+                # Check for any commits that have not been pushed
                 CURRENT_BRANCH=`git branch --show-current`
                 echo "[resolver] Current branch: ${CURRENT_BRANCH}"
                 
@@ -249,7 +249,7 @@ jobs:
                 if git log origin/main..HEAD --oneline 2>/dev/null | grep -q .; then
                     echo "[resolver] Found unpushed commits. Creating PR..."
                     
-                    # Create a branch name if we're on main
+                    # Create a branch name if we are on main
                     if [ "${CURRENT_BRANCH}" = "main" ]; then
                       BRANCH_NAME="openhands-fix-issue-${ISSUE_NUMBER}"
                       git checkout -b "${BRANCH_NAME}"


### PR DESCRIPTION
The apostrophe in 'we're' was breaking the single-quoted string passed to bash -lc