### PR TITLE
Renames CLI entry points to 'app'

### DIFF
--- a/agents/orchestrator/pyproject.toml
+++ b/agents/orchestrator/pyproject.toml
@@ -10,8 +10,8 @@ dependencies = [
 ]
 
 [project.scripts]
-plan = "planner:cli"
-validate_summary = "validator_summary:cli"
+plan = "planner:app"
+validate_summary = "validator_summary:app"
 
 [tool.setuptools]
 py-modules = ["planner", "validator_summary"]


### PR DESCRIPTION
Updates the pyproject.toml file to rename the command-line interface entry points from 'cli' to 'app'.

This change aligns the entry point names with a more conventional and descriptive term, improving project consistency and readability.