### PR TITLE
Uses PAT_TOKEN if available for authentication

### DIFF
--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
       issues: write
     env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}   # or ANTHROPIC_API_KEY with langchain-anthropic
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Allows the workflow to use a personal access token (PAT) for authentication if it's available, falling back to GITHUB_TOKEN if not. This provides more flexibility in managing workflow permissions.