### PR TITLE
fix: only trigger OpenHands workflow for fix-me label specifically

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -14,10 +14,11 @@ concurrency:
 
 jobs:
   resolve:
+    # Only run if the specific fix-me label was added or @openhands-agent was mentioned
     if: |
-      (github.event_name == 'issues' && contains(join(github.event.issue.labels.*.name, ','), 'fix-me')) ||
+      (github.event_name == 'issues' && github.event.label.name == 'fix-me') ||
       (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '@openhands-agent') && github.event.comment.user.type != 'Bot') ||
-      (github.event_name == 'pull_request' && contains(join(github.event.pull_request.labels.*.name, ','), 'fix-me'))
+      (github.event_name == 'pull_request' && github.event.label.name == 'fix-me')
     runs-on: ${{ vars.TARGET_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 60
     concurrency:


### PR DESCRIPTION
- Changed condition to check github.event.label.name == 'fix-me'
- This prevents workflow runs for other labels (test, ui, etc.)
- Reduces noise in the Actions tab
- Only the intended issues will trigger workflow runs