### PR TITLE
fix: update validation workflow to use Node.js 22

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: '20' }
+        with: { node-version: '22' }
       - name: Install deps
         working-directory: ./frontend
         run: npm ci


### PR DESCRIPTION
- Angular 20 requires Node.js 22.12+ minimum
- GitHub Actions was using Node 20 which caused validation failures
- Aligns with local development environment using nvm with Node 22